### PR TITLE
Non blocking consume

### DIFF
--- a/lib/qup/adapter/kestrel/queue.rb
+++ b/lib/qup/adapter/kestrel/queue.rb
@@ -64,9 +64,10 @@ class Qup::Adapter::Kestrel
     #
     # Returns a Message
     def consume(&block)
-      # queue name, max_items( 1 ), timeout_mse (10 seconds ), auto_abort_msec (16 minutes)
-      msg_list  = @client.get( @name, 1, 10_000, 1_000_000 )
+      # queue name, max_items( 1 ), timeout_mse (0 - don't block), auto_abort_msec (16 minutes)
+      msg_list  = @client.get( @name, 1, 0, 1_000_000 )
       q_item    = msg_list.first
+      return unless q_item
       q_message = ::Qup::Message.new( q_item.id, unmarshal_if_marshalled( q_item.data ))
       @open_messages[q_message.key] = q_item
       if block_given? then

--- a/lib/qup/adapter/redis/queue.rb
+++ b/lib/qup/adapter/redis/queue.rb
@@ -76,7 +76,8 @@ class Qup::Adapter::Redis
     #
     # Returns a Message
     def consume(&block)
-      queue_name, data = @client.brpop name, 0 # blocking pop
+      data = @client.rpop( name )
+      return if data.nil?
       message = ::Qup::Message.new( data.object_id, data )
       @open_messages[message.key] = message
       if block_given? then

--- a/spec/qup/shared_queue_examples.rb
+++ b/spec/qup/shared_queue_examples.rb
@@ -49,6 +49,11 @@ shared_examples Qup::QueueAPI do
         msg.data.should eq 'consumeable message'
       end
     end
+
+    it 'returns nil if the queue is empty (it is non-blocking)' do
+      queue.consume
+      queue.consume.should == nil
+    end
   end
 
   describe "#acknowledge" do


### PR DESCRIPTION
Changed Kestrel and Redis adapters to do a non-blocking consume. Set kestrel timeout to 0 (prevents raising Qup::Adapter::Kestrel::Thrift::Kestrel::Client::TransportException). 
