### PR TITLE
Fix message newline bug in Kestrel adapter.

### DIFF
--- a/lib/qup/adapter/kestrel/destination.rb
+++ b/lib/qup/adapter/kestrel/destination.rb
@@ -12,6 +12,11 @@ class Qup::Adapter::Kestrel
     # Internal: the name of the Queue or Topic
     attr_reader :name
 
+    # Utility method to return an array given either an array or scalar
+    def self.wrap(array_or_scalar)
+      array_or_scalar.is_a?(Array) ? array_or_scalar : [ array_or_scalar ]
+    end
+
     # Internal: Create a new Topic or Queue
     #
     # address - the Connection Address string for the Kestrel Client

--- a/lib/qup/adapter/kestrel/queue.rb
+++ b/lib/qup/adapter/kestrel/queue.rb
@@ -50,7 +50,7 @@ class Qup::Adapter::Kestrel
     #
     # Returns the Message that was put onto the Queue
     def produce( message )
-      @client.put( @name, Array( message ), 0 ) # do not expire the message
+      @client.put( @name, Destination.wrap(message), 0 ) # do not expire the message
       return ::Qup::Message.new( message.object_id, message )
     end
 
@@ -88,7 +88,7 @@ class Qup::Adapter::Kestrel
     def acknowledge( message )
       open_msg = @open_messages.delete( message.key )
       raise Qup::Error, "Message #{message.key} is not currently being consumed" unless open_msg
-      @client.confirm( @name, Array( message.key )  )
+      @client.confirm( @name, Destination.wrap( message.key ) )
     end
 
     #######

--- a/lib/qup/adapter/kestrel/topic.rb
+++ b/lib/qup/adapter/kestrel/topic.rb
@@ -60,7 +60,7 @@ class Qup::Adapter::Kestrel
     #
     # Returns nothing
     def publish( message )
-      @client.put( @name, Array( message ), 0 ) # do not expire the message
+      @client.put( @name, Destination.wrap( message ), 0 ) # do not expire the message
     end
 
     #######

--- a/spec/qup/shared_queue_examples.rb
+++ b/spec/qup/shared_queue_examples.rb
@@ -26,6 +26,11 @@ shared_examples Qup::QueueAPI do
     queue.depth.should eq 1
   end
 
+  it "#produce does not create multiple messages for newlines" do
+    queue.produce( "one\nsingle\nmessage" )
+    queue.depth.should eq 1
+  end
+
   it "#flush" do
     10.times { |x| queue.produce( "message #{x}" ) }
     queue.depth.should eq 10

--- a/spec/qup/shared_topic_examples.rb
+++ b/spec/qup/shared_topic_examples.rb
@@ -53,5 +53,11 @@ shared_examples Qup::TopicAPI do
         msg.data.should eq 'hi all'
       end
     end
+
+    it "#produce does not create multiple messages for newlines" do
+      p = @topic.publisher
+      p.publish( "one\nsingle\nmessage" )
+      @subs.first.depth.should eq 1
+    end
   end
 end


### PR DESCRIPTION
Messages containing newlines used to insert multiple messages because of
use of Array().
